### PR TITLE
Added IsActive and AlertId fields to ToDatabase method for CreateCautionaryAlert

### DIFF
--- a/Hackney.Shared.CautionaryAlerts/Factories/EntityFactory.cs
+++ b/Hackney.Shared.CautionaryAlerts/Factories/EntityFactory.cs
@@ -3,7 +3,6 @@ using Hackney.Shared.CautionaryAlerts.Boundary.Request;
 using Hackney.Shared.CautionaryAlerts.Domain;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
 using Hackney.Shared.CautionaryAlerts.Infrastructure.GoogleSheets;
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/Hackney.Shared.CautionaryAlerts/Factories/EntityFactory.cs
+++ b/Hackney.Shared.CautionaryAlerts/Factories/EntityFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using Hackney.Shared.CautionaryAlerts.Boundary.Request;
 using Hackney.Shared.CautionaryAlerts.Domain;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
@@ -120,7 +121,7 @@ namespace Hackney.Shared.CautionaryAlerts.Factories
             };
         }
 
-        public static PropertyAlertNew ToDatabase(this CreateCautionaryAlert entity)
+        public static PropertyAlertNew ToDatabase(this CreateCautionaryAlert entity, string AlertId, bool IsActive)
         {
             return new PropertyAlertNew()
             {
@@ -133,7 +134,9 @@ namespace Hackney.Shared.CautionaryAlerts.Factories
                 Code = entity.Alert.Code,
                 CautionOnSystem = entity.Alert.Description,
                 DateOfIncident = entity.IncidentDate.ToString("d", CultureInfo.InvariantCulture),
-                Reason = entity.IncidentDescription
+                Reason = entity.IncidentDescription,
+                IsActive = IsActive,
+                AlertId = AlertId,
             };
         }
 


### PR DESCRIPTION
This is so that requests to create cautionary alerts can specify the new IDs and set them to be active.