### PR TITLE
Added AlertID and IsActive to be able to retrieve these in API responses

### DIFF
--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/EntityFactoryTest.cs
@@ -78,34 +78,6 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
             // Assert
             task.Should().NotThrow<IndexOutOfRangeException>();
         }
-        
-        [Test]
-        public void CanCreateAPropertyAlertDomainObjectFromPropertyAlertNew()
-        {
-            // Arrange
-            var alertId = _fixture.Create<string>();
-            var propertyAlertNew = _fixture.Create<PropertyAlertNew>();
-            propertyAlertNew.AlertId = alertId;
-            
-            // Act
-            var response = propertyAlertNew.ToDomain();
-            
-            // Assert
-            response.DoorNumber.Should().Be(propertyAlertNew.DoorNumber);
-            response.Address.Should().Be(propertyAlertNew.Address);
-            response.Neighbourhood.Should().Be(propertyAlertNew.Neighbourhood);
-            response.DateOfIncident.Should().Be(propertyAlertNew.DateOfIncident);
-            response.Code.Should().Be(propertyAlertNew.Code);
-            response.CautionOnSystem.Should().Be(propertyAlertNew.CautionOnSystem);
-            response.PropertyReference.Should().Be(propertyAlertNew.PropertyReference);
-            response.Name.Should().Be(propertyAlertNew.PersonName);
-            response.Reason.Should().Be(propertyAlertNew.Reason);
-            response.AssureReference.Should().Be(propertyAlertNew.AssureReference);
-            response.PersonId.Should().Be(propertyAlertNew.MMHID);
-            response.AlertId.Should().Be(propertyAlertNew.AlertId);
-            response.IsActive.Should().Be(propertyAlertNew.IsActive);
-        }
-        
 
         [Test]
         public void CanCreateAPropertyAlertDomainObjectFromPropertyAlertNew()

--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/EntityFactoryTest.cs
@@ -78,6 +78,34 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
             // Assert
             task.Should().NotThrow<IndexOutOfRangeException>();
         }
+        
+        [Test]
+        public void CanCreateAPropertyAlertDomainObjectFromPropertyAlertNew()
+        {
+            // Arrange
+            var alertId = _fixture.Create<string>();
+            var propertyAlertNew = _fixture.Create<PropertyAlertNew>();
+            propertyAlertNew.AlertId = alertId;
+            
+            // Act
+            var response = propertyAlertNew.ToDomain();
+            
+            // Assert
+            response.DoorNumber.Should().Be(propertyAlertNew.DoorNumber);
+            response.Address.Should().Be(propertyAlertNew.Address);
+            response.Neighbourhood.Should().Be(propertyAlertNew.Neighbourhood);
+            response.DateOfIncident.Should().Be(propertyAlertNew.DateOfIncident);
+            response.Code.Should().Be(propertyAlertNew.Code);
+            response.CautionOnSystem.Should().Be(propertyAlertNew.CautionOnSystem);
+            response.PropertyReference.Should().Be(propertyAlertNew.PropertyReference);
+            response.Name.Should().Be(propertyAlertNew.PersonName);
+            response.Reason.Should().Be(propertyAlertNew.Reason);
+            response.AssureReference.Should().Be(propertyAlertNew.AssureReference);
+            response.PersonId.Should().Be(propertyAlertNew.MMHID);
+            response.AlertId.Should().Be(propertyAlertNew.AlertId);
+            response.IsActive.Should().Be(propertyAlertNew.IsActive);
+        }
+        
 
         [Test]
         public void CanCreatePropertyAlertNewFromCreateCautionaryAlert()

--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/EntityFactoryTest.cs
@@ -80,6 +80,33 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
         }
 
         [Test]
+        public void CanCreateAPropertyAlertDomainObjectFromPropertyAlertNew()
+        {
+            // Arrange
+            var alertId = _fixture.Create<string>();
+            var propertyAlertNew = _fixture.Create<PropertyAlertNew>();
+            propertyAlertNew.AlertId = alertId;
+
+            // Act
+            var response = propertyAlertNew.ToDomain();
+
+            // Assert
+            response.DoorNumber.Should().Be(propertyAlertNew.DoorNumber);
+            response.Address.Should().Be(propertyAlertNew.Address);
+            response.Neighbourhood.Should().Be(propertyAlertNew.Neighbourhood);
+            response.DateOfIncident.Should().Be(propertyAlertNew.DateOfIncident);
+            response.Code.Should().Be(propertyAlertNew.Code);
+            response.CautionOnSystem.Should().Be(propertyAlertNew.CautionOnSystem);
+            response.PropertyReference.Should().Be(propertyAlertNew.PropertyReference);
+            response.Name.Should().Be(propertyAlertNew.PersonName);
+            response.Reason.Should().Be(propertyAlertNew.Reason);
+            response.AssureReference.Should().Be(propertyAlertNew.AssureReference);
+            response.PersonId.Should().Be(propertyAlertNew.MMHID);
+            response.AlertId.Should().Be(propertyAlertNew.AlertId);
+            response.IsActive.Should().Be(propertyAlertNew.IsActive);
+        }
+
+        [Test]
         public void CanCreatePropertyAlertNewFromCreateCautionaryAlert()
         {
             // Arrange

--- a/Hackney.Shared.CautionaryAlerts/Domain/PropertyAlertDomain.cs
+++ b/Hackney.Shared.CautionaryAlerts/Domain/PropertyAlertDomain.cs
@@ -3,6 +3,7 @@ namespace Hackney.Shared.CautionaryAlerts.Domain
     public class PropertyAlertDomain
     {
         public int Id { get; set; }
+        public string AlertId { get; set; }
         public string DoorNumber { get; set; }
         public string Address { get; set; }
         public string Neighbourhood { get; set; }
@@ -15,5 +16,6 @@ namespace Hackney.Shared.CautionaryAlerts.Domain
         public string MMHID { get; set; }
         public string Reason { get; set; }
         public string AssureReference { get; set; }
+        public bool IsActive { get; set; }
     }
 }

--- a/Hackney.Shared.CautionaryAlerts/Factories/EntityFactory.cs
+++ b/Hackney.Shared.CautionaryAlerts/Factories/EntityFactory.cs
@@ -98,6 +98,8 @@ namespace Hackney.Shared.CautionaryAlerts.Factories
                 Reason = entity.Reason,
                 AssureReference = entity.AssureReference,
                 Id = entity.Id,
+                AlertId = entity.AlertId,
+                IsActive = entity.IsActive,
                 MMHID = entity.MMHID,
                 UPRN = entity.UPRN
             };


### PR DESCRIPTION
Currently they would be set in the database and returned in get request but not be returned in creation responses.

This also adds a test for the corresponding `ToDomain` method.