### PR TITLE
AlertQueryObject with validator and tests

### DIFF
--- a/Hackney.Shared.CautionaryAlerts.Tests/Boundary/Validation/AlertQueryValidatorTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Boundary/Validation/AlertQueryValidatorTest.cs
@@ -1,0 +1,58 @@
+﻿using FluentAssertions;
+using FluentValidation.TestHelper;
+using Hackney.Shared.CautionaryAlerts.Boundary.Request;
+using Hackney.Shared.CautionaryAlerts.Boundary.Request.Validation;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hackney.Shared.CautionaryAlerts.Tests.Boundary.Validation
+{
+    [TestFixture]
+    public class AlertQueryValidatorTest
+    {
+        private readonly AlertQueryValidator _classUnderTest;
+
+        public AlertQueryValidatorTest()
+        {
+            _classUnderTest = new AlertQueryValidator();
+        }
+
+        [Test]
+        public void AlertIdFailsIfEmpty()
+        {
+            var model = new AlertQueryObject { AlertId = Guid.Empty };
+            var result = _classUnderTest.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.AlertId);
+
+        }
+
+        [Test]
+        public void AlertIdNotFailsIfValid()
+        {
+            var model = new AlertQueryObject { AlertId = Guid.NewGuid() };
+            var result = _classUnderTest.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.AlertId);
+
+        }
+
+        [Test]
+        public void PersonIdFailsIfEmpty()
+        {
+            var model = new AlertQueryObject { PersonId = Guid.Empty };
+            var result = _classUnderTest.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.PersonId);
+
+        }
+
+        [Test]
+        public void PersonIdShouldNotFailIfValid()
+        {
+            var model = new AlertQueryObject { PersonId = Guid.NewGuid() };
+            var result = _classUnderTest.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.PersonId);
+
+        }
+    }
+}

--- a/Hackney.Shared.CautionaryAlerts/Boundary/Request/AlertQueryObject.cs
+++ b/Hackney.Shared.CautionaryAlerts/Boundary/Request/AlertQueryObject.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Hackney.Shared.CautionaryAlerts.Boundary.Request
+{
+    public class AlertQueryObject
+    {
+        [FromRoute(Name = "personId")]
+        public Guid PersonId { get; set; }
+
+        [FromRoute(Name = "alertId")]
+        public Guid AlertId { get; set; }
+    }
+}

--- a/Hackney.Shared.CautionaryAlerts/Boundary/Request/Validation/AlertQueryValidator.cs
+++ b/Hackney.Shared.CautionaryAlerts/Boundary/Request/Validation/AlertQueryValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Hackney.Shared.CautionaryAlerts.Boundary.Request.Validation
+{
+    public class AlertQueryValidator : AbstractValidator<AlertQueryObject>
+    {
+        public AlertQueryValidator()
+        {
+            RuleFor(x => x.AlertId).NotNull().NotEmpty();
+            RuleFor(x => x.PersonId).NotNull().NotEmpty();
+        }
+    }
+}


### PR DESCRIPTION
Ensures Empty guids are not sent through, as per comment in [this PR](https://github.com/LBHackney-IT/cautionary-alerts-api/pull/96#discussion_r1129221754)