### PR TITLE
Feature/return ca id and enddate

### DIFF
--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
@@ -109,6 +109,31 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
 
         }
 
+        [Test]
+        public void CanMapAPropertyAlertDomainObjectToACautionaryListItemResponse()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var propertyAlertDomain = fixture.Create<PropertyAlertDomain>();
+
+            // Act
+            var response = propertyAlertDomain.ToResponse();
+            
+            // Assert
+            response.AlertId.Should().Be(propertyAlertDomain.AlertId);
+            response.IsActive.Should().Be(propertyAlertDomain.IsActive);
+            response.DoorNumber.Should().Be(propertyAlertDomain.DoorNumber);
+            response.Address.Should().Be(propertyAlertDomain.Address);
+            response.AssureReference.Should().Be(propertyAlertDomain.AssureReference);
+            response.Code.Should().Be(propertyAlertDomain.Code);
+            response.DateOfIncident.Should().Be(propertyAlertDomain.DateOfIncident);
+            response.CautionOnSystem.Should().Be(propertyAlertDomain.CautionOnSystem);
+            response.Name.Should().Be(propertyAlertDomain.PersonName);
+            response.PropertyReference.Should().Be(propertyAlertDomain.PropertyReference);
+            response.Reason.Should().Be(propertyAlertDomain.Reason);
+            response.Neighbourhood.Should().Be(propertyAlertDomain.Neighbourhood);
+        }
+
 
     }
 }

--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
@@ -118,7 +118,7 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
 
             // Act
             var response = propertyAlertDomain.ToResponse();
-            
+
             // Assert
             response.AlertId.Should().Be(propertyAlertDomain.AlertId);
             response.IsActive.Should().Be(propertyAlertDomain.IsActive);

--- a/Hackney.Shared.CautionaryAlerts/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.CautionaryAlerts/Factories/ResponseFactory.cs
@@ -102,6 +102,8 @@ namespace Hackney.Shared.CautionaryAlerts.Factories
         {
             return new CautionaryAlertListItem()
             {
+                AlertId = domain.AlertId,
+                IsActive = domain.IsActive,
                 DoorNumber = domain.DoorNumber,
                 Address = domain.Address,
                 AssureReference = domain.AssureReference,


### PR DESCRIPTION
Currently cautionary alerts POST endpoint doesn't return cautionary alert ID and cautionary alert end date - updated the response object in this package so that these can be set in the cautionary alerts API.