### PR TITLE
Fix issue of Alert id returning empty guid

### DIFF
--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
@@ -140,8 +140,8 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
             // Arrange
             var fixture = new Fixture();
             var cautionaryAlertListItem = fixture.Build<CautionaryAlertListItem>()
-                                                 .With(x=> x.PersonId, Guid.NewGuid().ToString())
-                                                 .With(x=> x.AlertId, Guid.NewGuid().ToString())
+                                                 .With(x => x.PersonId, Guid.NewGuid().ToString())
+                                                 .With(x => x.AlertId, Guid.NewGuid().ToString())
                                                  .Create();
 
             // Act

--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
@@ -134,6 +134,32 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
             response.Neighbourhood.Should().Be(propertyAlertDomain.Neighbourhood);
         }
 
+        [Test]
+        public void CanMapACautionaryListItemToACautionaryAlertResponse()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var cautionaryAlertListItem = fixture.Build<CautionaryAlertListItem>()
+                                                 .With(x=> x.PersonId, Guid.NewGuid().ToString())
+                                                 .With(x=> x.AlertId, Guid.NewGuid().ToString())
+                                                 .Create();
+
+            // Act
+            var response = cautionaryAlertListItem.ToResponse();
+
+            // Assert
+            response.AlertId.Should().Be(cautionaryAlertListItem.AlertId);
+            response.IsActive.Should().Be(cautionaryAlertListItem.IsActive);
+            response.AlertCode.Should().Be(cautionaryAlertListItem.Code);
+            response.AssureReference.Should().Be(cautionaryAlertListItem.AssureReference);
+            response.DateModified.Should().Be(cautionaryAlertListItem.DateOfIncident);
+            response.Description.Should().Be(cautionaryAlertListItem.CautionOnSystem);
+            response.PersonId.Should().Be(cautionaryAlertListItem.PersonId);
+            response.PersonName.Should().Be(cautionaryAlertListItem.Name);
+            response.Reason.Should().Be(cautionaryAlertListItem.Reason);
+            response.StartDate.Should().Be(cautionaryAlertListItem.DateOfIncident);
+        }
+
 
     }
 }

--- a/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.CautionaryAlerts.Tests/Factories/ResponseFactoryTest.cs
@@ -63,6 +63,7 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
         {
             var fixture = new Fixture();
             var domain = fixture.Build<CautionaryAlertListItem>()
+                                .With(x => x.AlertId, Guid.NewGuid().ToString())
                                 .Without(x => x.PersonId)
                                 .Create();
             var response = domain.ToResponse();
@@ -77,6 +78,7 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
             var personId = Guid.NewGuid();
             var domain = fixture.Build<CautionaryAlertListItem>()
                                 .With(x => x.PersonId, personId.ToString())
+                                .With(x => x.AlertId, Guid.NewGuid().ToString())
                                 .Create();
             var response = domain.ToResponse();
             response.PersonId.Should().Be(personId);
@@ -90,6 +92,7 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
             var personId = Guid.Empty;
             var domain = fixture.Build<CautionaryAlertListItem>()
                                 .With(x => x.PersonId, personId.ToString())
+                                .With(x => x.AlertId, Guid.NewGuid().ToString())
                                 .Create();
             var response = domain.ToResponse();
             response.PersonId.Should().BeNull();
@@ -103,6 +106,7 @@ namespace Hackney.Shared.CautionaryAlerts.Tests.Factories
             var personId = "test";
             var domain = fixture.Build<CautionaryAlertListItem>()
                                 .With(x => x.PersonId, personId)
+                                .With(x => x.AlertId, Guid.NewGuid().ToString())
                                 .Create();
             var response = domain.ToResponse();
             response.PersonId.Should().BeNull();

--- a/Hackney.Shared.CautionaryAlerts/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.CautionaryAlerts/Factories/ResponseFactory.cs
@@ -82,7 +82,8 @@ namespace Hackney.Shared.CautionaryAlerts.Factories
                 AssureReference = domain.AssureReference,
                 PersonId = ParseGuidIfExists(domain.PersonId),
                 PersonName = domain.Name,
-                IsActive = domain.IsActive
+                IsActive = domain.IsActive,
+                AlertId = Guid.Parse(domain.AlertId)
             };
         }
 


### PR DESCRIPTION
For both Get Alerts by person id and get alerts by Property reference, there is an issue where the Alert id is returned with an empty guid. This is due to the Alert id not being parsed as part of the `ToResponse` method. This PR should resolve that issue and relevant tests for the method have been added as well. 